### PR TITLE
Adding non axisymmetric electric potenital perturbation

### DIFF
--- a/SRC/find_tetra_mod.f90
+++ b/SRC/find_tetra_mod.f90
@@ -9,7 +9,7 @@ module find_tetra_mod
 !
     private
 !
-    public :: grid_for_find_tetra, find_tetra
+    public :: grid_for_find_tetra, find_tetra, deallocate_find_tetra_arrays
 !
     integer, dimension(:,:), allocatable           :: equidistant_grid
     integer, dimension(:), allocatable             :: entry_counter
@@ -595,4 +595,20 @@ subroutine find_tetra(x,vpar,vperp,ind_tetr_out,iface,sign_t_step_in)
         endif
 !
     end subroutine find_tetra
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+    subroutine deallocate_find_tetra_arrays
+!
+! Deallocates arrays used by find_tetra to allow rebuilding with different grid
+!
+    implicit none
+!
+    if (allocated(equidistant_grid)) deallocate(equidistant_grid)
+    if (allocated(entry_counter)) deallocate(entry_counter)
+    if (allocated(box_centres)) deallocate(box_centres)
+    if (allocated(save_box_centres)) deallocate(save_box_centres)
+!
+    end subroutine deallocate_find_tetra_arrays
+!
 end module find_tetra_mod

--- a/SRC/find_tetra_mod.f90
+++ b/SRC/find_tetra_mod.f90
@@ -43,7 +43,10 @@ module find_tetra_mod
         real(dp), dimension(:,:), allocatable  :: verts_abc
 !
 print*, 'grid_for_find_tetra started'
-        boole_reduce_entries = .true.
+        !Free any pre-existing find-tetra arrays so a fresh build can proceed without external bookkeeping.
+        call deallocate_find_tetra_arrays
+!
+        boole_reduce_entries = .false.
         boole_axi_symmetry = .false.
 !
         if (coord_system.eq.1) allocate(verts_abc(size(verts_rphiz(:,1)),size(verts_rphiz(1,:))))

--- a/SRC/gorilla_settings_mod.f90
+++ b/SRC/gorilla_settings_mod.f90
@@ -61,11 +61,9 @@
     logical, public, protected :: boole_axi_noise_vector_pot
     logical, public, protected :: boole_axi_noise_elec_pot
     logical, public, protected :: boole_non_axi_noise_vector_pot
-    logical, public, protected :: boole_non_axi_noise_elec_pot
     double precision, public, protected :: axi_noise_eps_A
     double precision, public, protected :: axi_noise_eps_Phi
     double precision, public, protected :: non_axi_noise_eps_A
-    double precision, public, protected :: non_axi_noise_eps_Phi
 !
     !Manipulation of the axisymmetric electromagnetic field (Tokamak) with helical harmonic perturbation
     logical, public  :: boole_helical_pert
@@ -96,8 +94,8 @@
     NAMELIST /GORILLANML/ eps_Phi, coord_system, ispecies, ipusher, &
                         & boole_pusher_ode45, boole_dt_dtau, boole_newton_precalc, poly_order, i_precomp, boole_guess, &
                         & rel_err_ode45,boole_periodic_relocation,handover_processing_kind, boole_axi_noise_vector_pot, &
-                        & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, boole_non_axi_noise_elec_pot, &
-                        & axi_noise_eps_A, axi_noise_eps_Phi, non_axi_noise_eps_A, non_axi_noise_eps_Phi, &
+                        & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, &
+                        & axi_noise_eps_A, axi_noise_eps_Phi, non_axi_noise_eps_A, &
                         & boole_helical_pert, helical_pert_eps_Aphi, helical_pert_m_fourier, &
                         & helical_pert_n_fourier, boole_time_Hamiltonian, boole_gyrophase, boole_vpar_int, boole_vpar2_int, &
                         & boole_adaptive_time_steps, desired_delta_energy, max_n_intermediate_steps, boole_grid_for_find_tetra, &

--- a/SRC/gorilla_settings_mod.f90
+++ b/SRC/gorilla_settings_mod.f90
@@ -61,9 +61,11 @@
     logical, public, protected :: boole_axi_noise_vector_pot
     logical, public, protected :: boole_axi_noise_elec_pot
     logical, public, protected :: boole_non_axi_noise_vector_pot
+    logical, public, protected :: boole_non_axi_noise_elec_pot
     double precision, public, protected :: axi_noise_eps_A
     double precision, public, protected :: axi_noise_eps_Phi
     double precision, public, protected :: non_axi_noise_eps_A
+    double precision, public, protected :: non_axi_noise_eps_Phi
 !
     !Manipulation of the axisymmetric electromagnetic field (Tokamak) with helical harmonic perturbation
     logical, public  :: boole_helical_pert
@@ -94,8 +96,9 @@
     NAMELIST /GORILLANML/ eps_Phi, coord_system, ispecies, ipusher, &
                         & boole_pusher_ode45, boole_dt_dtau, boole_newton_precalc, poly_order, i_precomp, boole_guess, &
                         & rel_err_ode45,boole_periodic_relocation,handover_processing_kind, boole_axi_noise_vector_pot, &
-                        & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, axi_noise_eps_A, axi_noise_eps_Phi, &
-                        & non_axi_noise_eps_A, boole_helical_pert, helical_pert_eps_Aphi, helical_pert_m_fourier, &
+                        & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, boole_non_axi_noise_elec_pot, &
+                        & axi_noise_eps_A, axi_noise_eps_Phi, non_axi_noise_eps_A, non_axi_noise_eps_Phi, &
+                        & boole_helical_pert, helical_pert_eps_Aphi, helical_pert_m_fourier, &
                         & helical_pert_n_fourier, boole_time_Hamiltonian, boole_gyrophase, boole_vpar_int, boole_vpar2_int, &
                         & boole_adaptive_time_steps, desired_delta_energy, max_n_intermediate_steps, boole_grid_for_find_tetra, &
                         & a_factor, b_factor, c_factor, &

--- a/SRC/magdata_in_symfluxcoord.f90
+++ b/SRC/magdata_in_symfluxcoord.f90
@@ -123,6 +123,30 @@ module magdata_in_symfluxcoordinates_mod
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
+  subroutine deallocate_magdata_in_symfluxcoord
+!
+! Deallocates arrays to allow reloading with different grid parameters
+!
+  use magdata_in_symfluxcoor_mod
+!
+  implicit none
+!
+  if (allocated(rbeg)) deallocate(rbeg)
+  if (allocated(rsmall)) deallocate(rsmall)
+  if (allocated(qsaf)) deallocate(qsaf)
+  if (allocated(psisurf)) deallocate(psisurf)
+  if (allocated(phitor)) deallocate(phitor)
+  if (allocated(R_st)) deallocate(R_st)
+  if (allocated(Z_st)) deallocate(Z_st)
+  if (allocated(bmod_st)) deallocate(bmod_st)
+  if (allocated(sqgnorm_st)) deallocate(sqgnorm_st)
+!
+  load = .true.
+!
+  end subroutine deallocate_magdata_in_symfluxcoord
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
   subroutine magdata_in_symfluxcoord_ext(inp_label,s,psi,theta,q,dq_ds, &
                                          sqrtg,bmod,dbmod_dtheta,R,dR_ds,dR_dtheta,       &
                                          Z,dZ_ds,dZ_dtheta)

--- a/SRC/magdata_in_symfluxcoord.f90
+++ b/SRC/magdata_in_symfluxcoord.f90
@@ -33,6 +33,9 @@ module magdata_in_symfluxcoordinates_mod
   integer :: i,nthetap1
   double precision, dimension(:,:), allocatable :: splcoe
 !
+  !Free any pre-existing magdata arrays so a fresh load can proceed without external bookkeeping.
+  call deallocate_magdata_in_symfluxcoord
+!
   twopi = atan(1.d0)*8.d0
 !
 !-----------------------------------------------------------------------

--- a/SRC/points_2d.f90
+++ b/SRC/points_2d.f90
@@ -17,7 +17,7 @@ contains
 
 subroutine create_points_2d(inp_label,n_theta,points,points_s_theta_phi,r_scaling_func,theta_scaling_func,repeat_center_point)
 !
-    use tetra_grid_settings_mod, only: s_min => sfc_s_min,theta_geom_flux, n_extra_rings
+    use tetra_grid_settings_mod, only: s_min => sfc_s_min,theta_geom_flux, n_extra_rings, i_radial_spacing
     use magdata_in_symfluxcoor_mod, only: psipol_max
     use magdata_in_symfluxcoordinates_mod, only: magdata_in_symfluxcoord_ext
 !
@@ -37,7 +37,7 @@ subroutine create_points_2d(inp_label,n_theta,points,points_s_theta_phi,r_scalin
     integer :: n_center_point
 
     integer :: n
-    double precision :: s_second_ring
+    double precision :: s_second_ring, sqrt_s_min, sqrt_s
 !
     n_center_point = 1
     if (present(repeat_center_point)) then
@@ -58,21 +58,30 @@ subroutine create_points_2d(inp_label,n_theta,points,points_s_theta_phi,r_scalin
 !    ! this is done so we can then call magdata_in_symfluxcoord_ext on this interpolated fine grid.
 !    call load_magdata_in_symfluxcoord()
 
-! start: make first few entries of r_frac non-equidistant in order to avoid very thin triangles close to the magnetic axis
+! First compute the main radial grid (rings n+1 to nlabel)
     n = n_extra_rings
-
+!
+    select case(i_radial_spacing)
+        case(1)
+            !Equidistant in s (normalized toroidal flux) - default behavior
+            r_frac(n+1:nlabel) = s_min + [(dble(i)*(1.d0-s_min), i=1, nlabel-n, 1)] / (dble(nlabel-n))
+        case(2)
+            !Equidistant in sqrt(s) (approximately equidistant in minor radius)
+            sqrt_s_min = sqrt(s_min)
+            do i = 1, nlabel-n
+                sqrt_s = sqrt_s_min + dble(i) * (1.d0 - sqrt_s_min) / dble(nlabel-n)
+                r_frac(n+i) = sqrt_s**2
+            enddo
+    end select
+!
+! Now add extra rings between s_min and the first regular ring (r_frac(n+1))
+! These are spaced logarithmically to avoid very thin triangles close to the magnetic axis
     if (n.gt.0) then
-        s_second_ring = s_min + (1.d0-s_min)/(dble(nlabel-n+1))
+        s_second_ring = r_frac(n+1)
         do i = 1,n
             r_frac(i) = exp(log(s_min) + dble(i)*(log(s_second_ring)-log(s_min))/dble(n+1))
         enddo
     endif
-! end: make first few entries of r_frac non-equidistant in order to avoid very thin triangles close to the magnetic axis
-!      when using this version, be sure to comment out the line sstarting with "r_frac =" instead of "r_frac(n:nlabel) ="
-!
-    r_frac(n+1:nlabel) = s_min + [(dble(i)*(1.d0-s_min), i=1, nlabel-n, 1)] / (dble(nlabel-n))
-
-    ! r_frac = s_min + [(dble(i)*(1.d0-s_min), i=1, nlabel, 1)] / (dble(nlabel))
 !
     !r_frac = [(i, i = 1, nlabel,1)] / dfloat(nlabel)
     if (present(r_scaling_func)) r_frac = r_scaling_func(r_frac)
@@ -161,7 +170,7 @@ end subroutine create_points_2d
 !
   subroutine create_points_2d_vmec(n_theta, points_sthetaphi, r_scaling_func, theta_scaling_func, repeat_center_point)
 !
-    use tetra_grid_settings_mod, only: s_min => sfc_s_min
+    use tetra_grid_settings_mod, only: s_min => sfc_s_min, i_radial_spacing
 !
     integer, dimension(:), intent(in) :: n_theta
     !double precision, dimension(:,:), intent(out) :: points_rphiz
@@ -171,11 +180,12 @@ end subroutine create_points_2d
     double precision, dimension(size(n_theta)) :: r_frac
     integer :: nlabel, i, j, isurf, point_idx,n_theta_current
     integer :: n_center_point
-    
+
     double precision, dimension(:), allocatable :: theta_frac
 
     double precision :: s,theta,vartheta,varphi,A_phi,A_theta,dA_phi_ds,dA_theta_ds,aiota,       &
                         R,Z,alam,dR_ds,dR_dt,dR_dp,dZ_ds,dZ_dt,dZ_dp,dl_ds,dl_dt,dl_dp
+    double precision :: sqrt_s_min, sqrt_s
 !
     n_center_point = 1
     if (present(repeat_center_point)) then
@@ -187,7 +197,18 @@ end subroutine create_points_2d
     nlabel = size(n_theta)
     allocate(theta_frac(maxval(n_theta)))
 !
-    r_frac = s_min + [(dble(i)*(1.d0-s_min), i=1, size(r_frac), 1)] / (dble(nlabel))
+    select case(i_radial_spacing)
+        case(1)
+            !Equidistant in s (normalized toroidal flux) - default behavior
+            r_frac = s_min + [(dble(i)*(1.d0-s_min), i=1, size(r_frac), 1)] / (dble(nlabel))
+        case(2)
+            !Equidistant in sqrt(s) (approximately equidistant in minor radius)
+            sqrt_s_min = sqrt(s_min)
+            do i = 1, nlabel
+                sqrt_s = sqrt_s_min + dble(i) * (1.d0 - sqrt_s_min) / dble(nlabel)
+                r_frac(i) = sqrt_s**2
+            enddo
+    end select
     if (present(r_scaling_func)) r_frac = r_scaling_func(r_frac)
 !
     if(.not. allocated(r_frac_mod)) then

--- a/SRC/tetra_grid_mod.f90
+++ b/SRC/tetra_grid_mod.f90
@@ -711,5 +711,21 @@ b: do ind_tetr=1,ntetr
 !
     end subroutine check_neighbour
 !
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+    subroutine deallocate_tetra_grid
+!
+! Deallocates tetra_grid arrays to allow rebuilding with different parameters
+!
+    implicit none
+!
+    if (allocated(tetra_grid)) deallocate(tetra_grid)
+    if (allocated(verts_rphiz)) deallocate(verts_rphiz)
+    if (allocated(verts_xyz)) deallocate(verts_xyz)
+    if (allocated(verts_sthetaphi)) deallocate(verts_sthetaphi)
+    if (allocated(verts_theta_vmec)) deallocate(verts_theta_vmec)
+!
+    end subroutine deallocate_tetra_grid
+!
 end module tetra_grid_mod
 

--- a/SRC/tetra_grid_mod.f90
+++ b/SRC/tetra_grid_mod.f90
@@ -41,6 +41,9 @@
         double precision :: rrr,ppp,zzz,B_r,B_p,B_z,dBrdR,dBrdp,dBrdZ    &
                             ,dBpdR,dBpdp,dBpdZ,dBzdR,dBzdp,dBzdZ
 !
+        !Free any pre-existing grid arrays so a fresh grid can be built without external bookkeeping.
+        call deallocate_tetra_grid()
+!
         call set_grid_size([n1,n2,n3])      !Rectangular grid:                  [n1,n2,n3] = [nR,nphi,nZ]
                                             !Field-aligned grid:                [n1,n2,n3] = [ns,nphi,ntheta]
 !        

--- a/SRC/tetra_grid_settings_mod.f90
+++ b/SRC/tetra_grid_settings_mod.f90
@@ -59,7 +59,7 @@
                             & g_file_filename,convex_wall_filename,netcdf_filename, &
                             & knots_SOLEDGE3X_EIRENE_filename, triangles_SOLEDGE3X_EIRENE_filename
 !
-    public :: load_tetra_grid_inp,set_grid_size,set_n_field_periods
+    public :: load_tetra_grid_inp,set_grid_size,set_n_field_periods,set_n2,set_n3
 !
     contains
 !
@@ -114,6 +114,30 @@
             grid_size(1) = grid_size(1) + n_extra_rings
 !
         end subroutine set_grid_size
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+        subroutine set_n2(n2_in)
+!
+            implicit none
+!
+            integer,intent(in)    :: n2_in
+!
+            n2 = n2_in
+!
+        end subroutine set_n2
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+        subroutine set_n3(n3_in)
+!
+            implicit none
+!
+            integer,intent(in)    :: n3_in
+!
+            n3 = n3_in
+!
+        end subroutine set_n3
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !

--- a/SRC/tetra_grid_settings_mod.f90
+++ b/SRC/tetra_grid_settings_mod.f90
@@ -40,6 +40,11 @@
     !Symmetry Flux Coordinates Annulus
     double precision,public,protected :: sfc_s_min
 !
+    !Radial grid spacing option
+    !1 ... equidistant in s (normalized toroidal flux) - default
+    !2 ... equidistant in sqrt(s) (approximately equidistant in minor radius)
+    integer, public, protected :: i_radial_spacing
+!
     !Scaling of $\theta$-variable
     integer, public, protected :: theta_geom_flux
 !
@@ -55,6 +60,7 @@
 !
     !Namelist for Tetrahedronal Grid input
     NAMELIST /TETRA_GRID_NML/ n1, n2, n3, grid_kind,boole_n_field_periods,n_field_periods_manual,sfc_s_min, &
+                            & i_radial_spacing, &
                             & boole_write_mesh_obj,filename_mesh_rphiz,filename_mesh_sthetaphi,theta_geom_flux,theta0_at_xpoint, &
                             & g_file_filename,convex_wall_filename,netcdf_filename, &
                             & knots_SOLEDGE3X_EIRENE_filename, triangles_SOLEDGE3X_EIRENE_filename

--- a/SRC/tetra_physics_mod.f90
+++ b/SRC/tetra_physics_mod.f90
@@ -124,17 +124,17 @@
 !   
   contains
 !
-    subroutine make_tetra_physics(coord_system_in,ipert_in,bmod_multiplier_in, i_option)
+    subroutine make_tetra_physics(coord_system_in,ipert_in,bmod_multiplier_in, boole_keep_phi_elec)
 !
       use tetra_grid_mod, only: tetra_grid,verts_rphiz,verts_sthetaphi,verts_theta_vmec,ntetr,nvert, &
                                 & set_verts_sthetaphi,verts_xyz
-      use tetra_grid_settings_mod, only: grid_kind,grid_size,n_field_periods
+      use tetra_grid_settings_mod, only: grid_kind,grid_size,n_field_periods,n_extra_rings
       use constants, only: pi
       use field_mod, only: ipert
       use various_functions_mod, only: dmatinv3
       use gorilla_settings_mod, only: eps_Phi,handover_processing_kind, boole_axi_noise_vector_pot, &
-            & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, boole_non_axi_noise_elec_pot, &
-            & axi_noise_eps_A, axi_noise_eps_Phi, non_axi_noise_eps_A, non_axi_noise_eps_Phi, &
+            & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, &
+            & axi_noise_eps_A, axi_noise_eps_Phi, non_axi_noise_eps_A, &
             & boole_strong_electric_field, boole_save_electric, boole_pert_from_mephit
       use strong_electric_field_mod, only: get_electric_field, save_electric_field, get_v_E, save_v_E
       use differentiate_mod, only: differentiate
@@ -144,11 +144,11 @@
 !
       integer, intent(in) :: ipert_in,coord_system_in
       double precision, intent(in),optional :: bmod_multiplier_in
-      integer, intent(in), optional :: i_option
+      logical, intent(in), optional :: boole_keep_phi_elec
       integer :: iv,i,j,k,l,ind_tetr,ierr
       integer :: nr,nphi,nz,navec,inp_label
       integer,dimension(4) :: vertex_indices
-      double precision :: rnd_non_axi_noise_x1,rnd_non_axi_noise_x2,rnd_non_axi_noise_x3,rnd_non_axi_noise_phi_elec, bmod_multiplier,met_det
+      double precision :: rnd_non_axi_noise_x1,rnd_non_axi_noise_x2,rnd_non_axi_noise_x3,bmod_multiplier,met_det
       double precision, dimension(4)   :: p_x1,p_x2,p_x3
       double precision, dimension(3) :: cur_comp1, cur_comp2, cur_comp3
       double precision, dimension(3) :: curCoordi
@@ -239,7 +239,7 @@
       !Manipulation of the axisymmetric electromagnetic field with noise
       ! - Check that noise is only added in the case of axisymmetric electromagnetic field
       ! - Precompute noise in the case of axisymmetric noise
-      if(boole_axi_noise_vector_pot.or.boole_axi_noise_elec_pot.or.boole_non_axi_noise_vector_pot.or.boole_non_axi_noise_elec_pot) then
+      if(boole_axi_noise_vector_pot.or.boole_axi_noise_elec_pot.or.boole_non_axi_noise_vector_pot) then
             select case(grid_kind)
                 case(1,2)
                     if(boole_axi_noise_vector_pot.or.boole_axi_noise_elec_pot) then
@@ -411,9 +411,9 @@
                                 & v_E_x1(iv),v_E_x2(iv),v_E_x3(iv),v2_E_mod(iv))
         else
             !Electrostatic potential as a product of co-variant component of vector potential and a factor eps_Phi (gorilla.inp)
-            if (present(i_option)) then
-              if (i_option.eq.12) then
-                !Do nothing, phi_elec is written on from the outside
+            if (present(boole_keep_phi_elec)) then
+              if (boole_keep_phi_elec) then
+                !Do nothing, phi_elec is set from outside and should not be overwritten
               else
                 phi_elec(iv) = A_x2(iv)*eps_Phi
               endif
@@ -425,12 +425,6 @@
         !Optionally add axisymmetric noise to electrostatic potential
         if(boole_axi_noise_elec_pot) then
             phi_elec(iv) = phi_elec(iv)+phi_elec(iv)*axi_noise_eps_Phi*rnd_axi_noise(modulo(iv-1,(nvert/grid_size(2))) +1)
-        endif
-
-        !Optionally add non-axisymmetric noise to electrostatic potential
-        if(boole_non_axi_noise_elec_pot) then
-            call random_number(rnd_non_axi_noise_phi_elec)
-            phi_elec(iv) = phi_elec(iv)+phi_elec(iv)*non_axi_noise_eps_Phi*rnd_non_axi_noise_phi_elec
         endif
 !
       enddo !iv (index vertex)

--- a/SRC/tetra_physics_mod.f90
+++ b/SRC/tetra_physics_mod.f90
@@ -175,24 +175,36 @@
       integer          :: triangle, n_fourier_modes
       complex, dimension(:,:), allocatable :: A_x1_mat, A_x2_mat, A_x3_mat, b_x1_mat, b_x2_mat, b_x3_mat
 !
+      !Deallocate any pre-existing module arrays so a fresh grid can be built without external bookkeeping.
+      !phi_elec is preserved when the caller asks for it (self-consistent electric field workflow),
+      !in which case the caller is responsible for it being correctly sized for the current nvert.
+      if (allocated(tetra_physics))    deallocate(tetra_physics)
+      if (allocated(tetra_skew_coord)) deallocate(tetra_skew_coord)
+      if (allocated(hamiltonian_time)) deallocate(hamiltonian_time)
+      if (present(boole_keep_phi_elec)) then
+        if (.not.boole_keep_phi_elec) then
+          if (allocated(phi_elec)) deallocate(phi_elec)
+        endif
+      else
+        if (allocated(phi_elec)) deallocate(phi_elec)
+      endif
+!
       !Allocation of quantities dependent on number of vertices
-      if (.not.allocated(tetra_physics)) allocate(tetra_physics(ntetr))
+      allocate(tetra_physics(ntetr))
       allocate(A_x1(nvert),A_x2(nvert),A_x3(nvert))
       allocate(bmod(nvert),h_x1(nvert),h_x2(nvert),h_x3(nvert))
       if (.not.allocated(phi_elec)) allocate(phi_elec(nvert))
 !
       !Hamiltonian time quantities
-      if (.not.allocated(hamiltonian_time)) allocate(hamiltonian_time(ntetr))
+      allocate(hamiltonian_time(ntetr))
 !
-      if (.not.allocated(tetra_skew_coord)) then
-        !Distinguish the Processing of particle handover to tetrahedron neighbour
-        select case(handover_processing_kind)
-            case(1) !Processing with special treatment of periodic boundaries and manipulation of periodic position values
-                allocate(tetra_skew_coord(1)) !Dummy value for parallelization
-            case(2) !Position exchange via Cartesian variables (skew_coordinates) - Necessary precomputation is included below
-                allocate(tetra_skew_coord(ntetr))
-        end select
-      endif
+      !Distinguish the Processing of particle handover to tetrahedron neighbour
+      select case(handover_processing_kind)
+          case(1) !Processing with special treatment of periodic boundaries and manipulation of periodic position values
+              allocate(tetra_skew_coord(1)) !Dummy value for parallelization
+          case(2) !Position exchange via Cartesian variables (skew_coordinates) - Necessary precomputation is included below
+              allocate(tetra_skew_coord(ntetr))
+      end select
 !
       !Distinguish, in between EFIT and VMEC
       if(grid_kind.eq.3) then !VMEC

--- a/SRC/tetra_physics_mod.f90
+++ b/SRC/tetra_physics_mod.f90
@@ -1,4 +1,5 @@
 !
+
   module tetra_physics_mod
 
     use, intrinsic :: iso_fortran_env, only: dp => real64
@@ -132,8 +133,9 @@
       use field_mod, only: ipert
       use various_functions_mod, only: dmatinv3
       use gorilla_settings_mod, only: eps_Phi,handover_processing_kind, boole_axi_noise_vector_pot, &
-            & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, axi_noise_eps_A, axi_noise_eps_Phi, &
-            & non_axi_noise_eps_A, boole_strong_electric_field, boole_save_electric, boole_pert_from_mephit
+            & boole_axi_noise_elec_pot, boole_non_axi_noise_vector_pot, boole_non_axi_noise_elec_pot, &
+            & axi_noise_eps_A, axi_noise_eps_Phi, non_axi_noise_eps_A, non_axi_noise_eps_Phi, &
+            & boole_strong_electric_field, boole_save_electric, boole_pert_from_mephit
       use strong_electric_field_mod, only: get_electric_field, save_electric_field, get_v_E, save_v_E
       use differentiate_mod, only: differentiate
       use splint_vmec_data_mod, only: splint_vmec_data
@@ -146,7 +148,7 @@
       integer :: iv,i,j,k,l,ind_tetr,ierr
       integer :: nr,nphi,nz,navec,inp_label
       integer,dimension(4) :: vertex_indices
-      double precision :: rnd_non_axi_noise_x1,rnd_non_axi_noise_x2,rnd_non_axi_noise_x3, bmod_multiplier,met_det
+      double precision :: rnd_non_axi_noise_x1,rnd_non_axi_noise_x2,rnd_non_axi_noise_x3,rnd_non_axi_noise_phi_elec, bmod_multiplier,met_det
       double precision, dimension(4)   :: p_x1,p_x2,p_x3
       double precision, dimension(3) :: cur_comp1, cur_comp2, cur_comp3
       double precision, dimension(3) :: curCoordi
@@ -237,7 +239,7 @@
       !Manipulation of the axisymmetric electromagnetic field with noise
       ! - Check that noise is only added in the case of axisymmetric electromagnetic field
       ! - Precompute noise in the case of axisymmetric noise
-      if(boole_axi_noise_vector_pot.or.boole_axi_noise_elec_pot.or.boole_non_axi_noise_vector_pot) then
+      if(boole_axi_noise_vector_pot.or.boole_axi_noise_elec_pot.or.boole_non_axi_noise_vector_pot.or.boole_non_axi_noise_elec_pot) then
             select case(grid_kind)
                 case(1,2)
                     if(boole_axi_noise_vector_pot.or.boole_axi_noise_elec_pot) then
@@ -423,6 +425,12 @@
         !Optionally add axisymmetric noise to electrostatic potential
         if(boole_axi_noise_elec_pot) then
             phi_elec(iv) = phi_elec(iv)+phi_elec(iv)*axi_noise_eps_Phi*rnd_axi_noise(modulo(iv-1,(nvert/grid_size(2))) +1)
+        endif
+
+        !Optionally add non-axisymmetric noise to electrostatic potential
+        if(boole_non_axi_noise_elec_pot) then
+            call random_number(rnd_non_axi_noise_phi_elec)
+            phi_elec(iv) = phi_elec(iv)+phi_elec(iv)*non_axi_noise_eps_Phi*rnd_non_axi_noise_phi_elec
         endif
 !
       enddo !iv (index vertex)

--- a/SRC/tetra_physics_mod.f90
+++ b/SRC/tetra_physics_mod.f90
@@ -1347,5 +1347,20 @@ enddo
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !
+      subroutine deallocate_tetra_physics
+!
+! Deallocates tetra_physics arrays to allow rebuilding with different grid
+!
+        implicit none
+!
+        if (allocated(tetra_physics)) deallocate(tetra_physics)
+        if (allocated(tetra_skew_coord)) deallocate(tetra_skew_coord)
+        if (allocated(hamiltonian_time)) deallocate(hamiltonian_time)
+        if (allocated(phi_elec)) deallocate(phi_elec)
+!
+      end subroutine deallocate_tetra_physics
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
   end module tetra_physics_mod
 

--- a/SRC/tetra_physics_poly_precomp_mod.f90
+++ b/SRC/tetra_physics_poly_precomp_mod.f90
@@ -65,7 +65,8 @@ module tetra_physics_poly_precomp_mod
     !$OMP THREADPRIVATE(tetra_physics_poly_perpinv,boole_precomp_poly_perpinv)
 !
     public :: make_precomp_poly,make_precomp_poly_perpinv, &
-            & initialize_boole_precomp_poly_perpinv,alloc_precomp_poly_perpinv
+            & initialize_boole_precomp_poly_perpinv,alloc_precomp_poly_perpinv, &
+            & deallocate_precomp_poly
 !    
     contains
 !
@@ -559,6 +560,21 @@ module tetra_physics_poly_precomp_mod
             boole_precomp_poly_perpinv(i) = .true.
 !
         end subroutine make_precomp_poly_perpinv
+!
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!
+        subroutine deallocate_precomp_poly
+!
+! Deallocates precomputed polynomial arrays to allow rebuilding with different grid
+!
+        implicit none
+!
+        if (allocated(tetra_physics_poly1)) deallocate(tetra_physics_poly1)
+        if (allocated(tetra_physics_poly4)) deallocate(tetra_physics_poly4)
+        if (allocated(tetra_physics_poly_perpinv)) deallocate(tetra_physics_poly_perpinv)
+        if (allocated(boole_precomp_poly_perpinv)) deallocate(boole_precomp_poly_perpinv)
+!
+        end subroutine deallocate_precomp_poly
 !
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !

--- a/SRC/tetra_physics_poly_precomp_mod.f90
+++ b/SRC/tetra_physics_poly_precomp_mod.f90
@@ -76,6 +76,9 @@ module tetra_physics_poly_precomp_mod
 !
             implicit none
 !
+            !Free any pre-existing precomputed polynomial arrays so a fresh build can proceed without external bookkeeping.
+            call deallocate_precomp_poly
+!
             select case(ipusher)
                 case(1) !numerical RK pusher
 !


### PR DESCRIPTION
The possibility is added to determine electric fields externally (i.e. from GORILLA APPLETS). To this end, the variable boole_keep_phi_elec is introduced. Also, various deallocation routines are introduced that have to be called before running make_tetra_physics again.