### PR TITLE
Guard optional quantities against absent optional argument

### DIFF
--- a/SRC/pusher_tetra_poly.f90
+++ b/SRC/pusher_tetra_poly.f90
@@ -222,7 +222,8 @@ endif
             ! allocate(tau_steps_list(max_entries),intermediate_z0_list(4,max_entries))
             number_of_integration_steps = 0
 !
-            if (any(boole_array_optional_quantities)) call initialise_optional_quantities(optional_quantities)
+            if (present(optional_quantities) .and. any(boole_array_optional_quantities)) &
+                & call initialise_optional_quantities(optional_quantities)
 !
             !Initial computation values
             z = z_init
@@ -655,7 +656,7 @@ endif
 !                
             endif
 !
-            if(any(boole_array_optional_quantities)) then
+            if(present(optional_quantities) .and. any(boole_array_optional_quantities)) then
                 !loop over number_of_integration_steps
                 do i = 1,number_of_integration_steps
                     call calc_optional_quantities(poly_order, intermediate_z0_list(:,i), tau_steps_list(i), optional_quantities)


### PR DESCRIPTION
## Problem

`pusher_tetra_poly` declares `optional_quantities` as an `optional` argument,
but `orbit_timestep_gorilla` calls the pusher without passing it. When any
`boole_array_optional_quantities` switch is enabled in `gorilla.inp`, the pusher
still writes into that absent argument (via `initialise_optional_quantities` and
`calc_optional_quantities`), dereferencing a null pointer. The orbit integration
then segfaults on the first time step.

This is a deterministic crash, independent of platform and thread count.

## Change

Guard both call sites with `present(optional_quantities)`. Both `present(...)`
and `any(...)` are always safe to evaluate, so this does not rely on
short-circuit evaluation. When the caller omits the argument, the optional
quantities are simply not computed instead of crashing.

## Verification

Mono-energetic transport example (GORILLA_APPLETS) with
`boole_time_Hamiltonian = .true.` and `boole_gyrophase = .true.`, polynomial
pusher, on Linux (gfortran).

Before, single time step into the diffusion calculation:

```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
#3  initialise_optional_quantities at pusher_tetra_poly.f90:2121
#4  __pusher_tetra_poly_mod_MOD_pusher_tetra_poly at pusher_tetra_poly.f90:225
#5  __orbit_timestep_gorilla_mod_MOD_orbit_timestep_gorilla at orbit_timestep_gorilla.f90:126
```

After this change, the same configuration runs to completion:

```
pass2 exit=0
SIGSEGV count: 0
 Start calculation of diffusion coefficient
 Number of lost particles in Monte Carlo simulation           0
 D11: 1.0  0.4148  0.2262
```